### PR TITLE
feat(rule): no-empty-yuidoc-code-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ Then configure the rules you want to use under the rules section.
 
 - `require-yuidoc-access` - Ensures that every YUIDoc comment has `@public`, `@protected` or `@private` declared
 - `no-const-outside-module-scope` - Prevent `const` from being used outside of the module scope (e.g. in functions)
+- `no-empty-yuidoc-code-blocks` - Prevents empty code blocks in YUIDoc comments, e.g.
+
+    ```js
+    /**
+     * See code below:
+     *
+     * ```js
+     * ```
+     */
+    ```
 
 
 ## License

--- a/lib/rules/no-empty-yuidoc-code-blocks.js
+++ b/lib/rules/no-empty-yuidoc-code-blocks.js
@@ -1,0 +1,28 @@
+'use strict';
+
+function isDocComment(comment) {
+    return comment.value[0] === '*';
+}
+
+function hasEmptyCodeBlock(comment) {
+    return comment.value.match(/(^```(js|javascript|.+\.js\s*)$)(\s)*?(```$)/gm);
+}
+
+module.exports = function(context) {
+    var sourceCode = context.getSourceCode();
+
+    sourceCode.getAllComments().forEach(function(comment) {
+        if (comment.type !== 'Block') { return; }
+        if (!isDocComment(comment)) { return; }
+        if (!hasEmptyCodeBlock(comment)) { return; }
+
+        context.report({
+            loc: comment.loc.start,
+            message: 'Code blocks cannot be empty inside doc comments.'
+        });
+    });
+
+    return {}
+};
+
+module.exports.schema = []; // no options

--- a/tests/lib/rules/no-empty-yuidoc-code-blocks.js
+++ b/tests/lib/rules/no-empty-yuidoc-code-blocks.js
@@ -1,0 +1,27 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/no-empty-yuidoc-code-blocks');
+var RuleTester = require('eslint').RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+
+ruleTester.run('no-empty-yuidoc-code-blocks', rule, {
+    valid: [
+        '/**\n@module ember\n@submodule ember-application\n```js\nlet test = 5;\nconsole.log(test);\n```\n*/\n',
+        '/**\n@module ember\n@submodule ember-application\n```javascript\nlet test = 5;\n```\n*/\n'
+    ],
+
+    invalid: [{
+        code: '/**\nDummy method.\n```js\n```\n\n@method foo\n@return {String}\n*/',
+        errors: [{ message: 'Code blocks cannot be empty inside doc comments.' }]
+    }]
+});


### PR DESCRIPTION
Prevent having an empty code block, e.g.

\`\`\`js
\`\`\`

in your yui docs