### PR TITLE
Corrected REs on yuidoc access so that they don't misfire from CRs

### DIFF
--- a/lib/rules/require-yuidoc-access.js
+++ b/lib/rules/require-yuidoc-access.js
@@ -5,11 +5,11 @@ function isDocComment(comment) {
 }
 
 function isModuleOnlyComment(comment) {
-    return comment.value.match(/^\*\n\s*@module.+\n(?:\s*@submodule.+\n)?$/);
+    return comment.value.match(/^\*\r?\n\s*@module.+\r?\n(?:\s*@submodule.+\r?\n)?$/);
 }
 
 function includesAccessDeclaration(comment) {
-    return comment.value.match(/\n\s*(@private|@public|@protected)\s/);
+    return comment.value.match(/\r?\n\s*(@private|@public|@protected)\s/);
 }
 
 module.exports = function(context) {


### PR DESCRIPTION
I was getting a ton of eslint messages on Windows because the REs in require-yuidoc-access were only matching newlines without carriage returns. I adjusted the REs to allow for optional \r before \n, and now eslint is behaving the same for me on Windows and Mac. I've been using this tweak for a few days without issue and am only now giving it a PR to share it back with the rest of the team.