### PR TITLE
Add `--fix` support to `no-const-outside-module` rule

### DIFF
--- a/lib/rules/no-const-outside-module-scope.js
+++ b/lib/rules/no-const-outside-module-scope.js
@@ -1,29 +1,32 @@
 'use strict';
 
-module.exports = function(context) {
-  return {
-    VariableDeclaration: function(node) {
-      if (node.kind !== 'const') {
-        return;
-      }
+module.exports = {
+  meta: { fixable: 'code', schema: [] },
+  create(context) {
+    return {
+      VariableDeclaration: function(node) {
+        if (node.kind !== 'const') {
+          return;
+        }
 
-      if (node.parent && node.parent.type === 'Program') {
-        // Declaration is in root of module.
-        return;
-      }
+        if (node.parent && node.parent.type === 'Program') {
+          // Declaration is in root of module.
+          return;
+        }
 
-      if (node.parent && node.parent.type === 'ExportNamedDeclaration' &&
-        node.parent.parent && node.parent.parent.type === 'Program') {
-        // Declaration is a `export const foo = 'asdf'` in root of the module.
-        return;
-      }
+        if (node.parent && node.parent.type === 'ExportNamedDeclaration' &&
+          node.parent.parent && node.parent.parent.type === 'Program') {
+          // Declaration is a `export const foo = 'asdf'` in root of the module.
+          return;
+        }
 
-      context.report({
-        node: node,
-        message: '`const` should only be used in module scope (not inside functions/blocks).'
-      });
-    }
-  };
+        context.report({
+          node: node,
+          message: '`const` should only be used in module scope (not inside functions/blocks).'
+        });
+      }
+    };   
+  }
 };
 
 module.exports.schema = []; // no options

--- a/lib/rules/no-const-outside-module-scope.js
+++ b/lib/rules/no-const-outside-module-scope.js
@@ -22,7 +22,18 @@ module.exports = {
 
         context.report({
           node: node,
-          message: '`const` should only be used in module scope (not inside functions/blocks).'
+          message: '`const` should only be used in module scope (not inside functions/blocks).',
+          fix(fixer) {
+            // Get node's text content
+            let nodeSourceCode = context.getSourceCode();
+            let nodeText = nodeSourceCode.getText(node);
+
+            // Transform the `const` to a `let` declaration
+            let fixed = nodeText.replace('const', 'let')
+
+            // // Apply and return the fix
+            return fixer.replaceText(node, fixed);
+          }
         });
       }
     };   

--- a/tests/lib/rules/no-const-outside-module-scope.js
+++ b/tests/lib/rules/no-const-outside-module-scope.js
@@ -27,9 +27,11 @@ ruleTester.run('no-const-outside-module-scope', rule, {
 
   invalid: [{
     code: '{ const FOOBAR = 5; }',
+    output: '{ let FOOBAR = 5; }',
     errors: [{ message: '`const` should only be used in module scope (not inside functions/blocks).' }]
   }, {
     code: 'function foobar() { const FOOBAR = 5; return FOOBAR; }',
+    output: 'function foobar() { let FOOBAR = 5; return FOOBAR; }',
     errors: [{ message: '`const` should only be used in module scope (not inside functions/blocks).' }]
   }]
 });

--- a/tests/lib/rules/no-const-outside-module-scope.js
+++ b/tests/lib/rules/no-const-outside-module-scope.js
@@ -22,7 +22,17 @@ var ruleTester = new RuleTester({
 ruleTester.run('no-const-outside-module-scope', rule, {
   valid: [
     'const FOOBAR = 5;',
-    'export const FOOBAR = 5;'
+    'export const FOOBAR = 5;',
+    `
+      import Controller from '@ember/controller';
+      const COUNT = 5;
+      export default class extends Controller {
+        get count() {
+          let listCount = this.module.scope ? this.list.length : COUNT;
+          return listCount;
+        }
+      }
+    `
   ],
 
   invalid: [{
@@ -32,6 +42,26 @@ ruleTester.run('no-const-outside-module-scope', rule, {
   }, {
     code: 'function foobar() { const FOOBAR = 5; return FOOBAR; }',
     output: 'function foobar() { let FOOBAR = 5; return FOOBAR; }',
+    errors: [{ message: '`const` should only be used in module scope (not inside functions/blocks).' }]
+  }, {
+    code: `
+      import Controller from '@ember/controller';
+      export default class extends Controller {
+        get isControllerScope() {
+          const { scope } = this
+          return Boolean(scope)
+        }
+      }
+    `,
+    output: `
+      import Controller from '@ember/controller';
+      export default class extends Controller {
+        get isControllerScope() {
+          let { scope } = this
+          return Boolean(scope)
+        }
+      }
+    `,
     errors: [{ message: '`const` should only be used in module scope (not inside functions/blocks).' }]
   }]
 });


### PR DESCRIPTION
This MR aims to solve [this opened issue](https://github.com/emberjs/eslint-plugin-ember-internal/issues/20).

We're adding a `--fix` support for the `no-const-outside-module-scope` rule. In order to make this rule more usable in existing Ember projects.

As described in the concerned commit, running the `--fix` option will replace the invalid `const` declarations by `let ` declarations.

Feel free to challenge the solution.
I also explored an other fix possibility: moving the invalid `const` declarations up to the module's scope. But it would have created conflicts if several variables with the same name in different scopes are merged in the same scope.