### PR TITLE
Drop support for Node 10, 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '10', '12', '14', '16', '18' ]
+        node: [ '14', '16', '18' ]
     name: Node ${{ matrix.node }} tests
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.0"
   },
+  "engines": {
+    "node": "^14.18.0 || ^16.0.0 || >=18.0.0"
+  },
   "license": "MIT",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
Match eslint-plugin-ember: https://github.com/ember-cli/eslint-plugin-ember/blob/master/package.json#L111-L113

These versions are end-of-life.

Related: https://github.com/ember-cli/eslint-plugin-ember/pull/1318